### PR TITLE
Add dependencies for targetFramework MonoAndroid13

### DIFF
--- a/Scanbot.Xamarin.SDK.Dependencies/Scanbot.Xamarin.SDK.Dependencies.nuspec
+++ b/Scanbot.Xamarin.SDK.Dependencies/Scanbot.Xamarin.SDK.Dependencies.nuspec
@@ -2,7 +2,7 @@
 <package>
     <metadata>
         <id>Scanbot.NET.SDK.Dependencies</id>
-        <version>1.0.0-beta.3</version>
+        <version>1.0.0-beta.4</version>
         <title>Scanbot SDK Dependencies</title>
         <description>A collection of dependencies required by Scanbot SDK and Scanbot Barcode Scanner SDK (not meant to be used as a separate NuGet package)</description>
         <authors>Scanbot</authors>
@@ -11,6 +11,50 @@
         <requireLicenseAcceptance>false</requireLicenseAcceptance>
         <copyright>Copyright 2023 Scanbot SDK GmbH</copyright>
         <dependencies>
+            <group targetFramework="MonoAndroid13.0">
+                <dependency id="Xamarin.AndroidX.Annotation.Experimental" version="1.3.1.3" include="All" />
+                <dependency id="Xamarin.AndroidX.Annotation" version="1.7.0.2" include="All" />
+                <dependency id="Xamarin.Android.ReactiveX.RxJava" version="2.2.21.14" include="All" />
+                <dependency id="Xamarin.Android.ReactiveX.RxJava3.RxJava" version="3.1.8.1" include="All" />
+                <dependency id="Xamarin.AndroidX.Activity" version="1.8.0.1" include="All" />
+                <dependency id="Xamarin.AndroidX.Activity.Ktx" version="1.8.0.1" include="All" />
+                <dependency id="Xamarin.AndroidX.Collection.Ktx" version="1.3.0.1" include="All" />
+                <dependency id="Xamarin.AndroidX.Fragment.Ktx" version="1.6.1.2" include="All" />
+                <dependency id="Xamarin.AndroidX.AppCompat" version="1.6.1.5" include="All" />
+                <dependency id="Xamarin.AndroidX.ConstraintLayout" version="2.1.4.8" include="All" />
+                <dependency id="Xamarin.AndroidX.Arch.Core.Runtime" version="2.2.0.5" include="All" />
+                <dependency id="Xamarin.AndroidX.DynamicAnimation" version="1.0.0.21" include="All" />
+                <dependency id="Xamarin.AndroidX.DataBinding.ViewBinding" version="8.1.2.1" include="All" />
+                <dependency id="Xamarin.AndroidX.SwipeRefreshLayout" version="1.1.0.16" include="All" />
+                <dependency id="Xamarin.AndroidX.Legacy.Support.V4" version="1.0.0.21" include="All" />
+                <dependency id="Xamarin.AndroidX.Core" version="1.12.0.2" include="All" />
+                <dependency id="Xamarin.AndroidX.Core.Core.Ktx" version="1.12.0.2" include="All" />
+                <dependency id="Xamarin.AndroidX.Camera.Core" version="1.2.0" include="All" />
+                <dependency id="Xamarin.AndroidX.Camera.Camera2" version="1.2.0" include="All" />
+                <dependency id="Xamarin.AndroidX.Camera.Lifecycle" version="1.2.0" include="All" />
+                <dependency id="Xamarin.AndroidX.Camera.View" version="1.2.0" include="All" />
+                <dependency id="Xamarin.AndroidX.Lifecycle.Common" version="2.6.2.2" include="All" />
+                <dependency id="Xamarin.AndroidX.Lifecycle.ViewModel.Ktx" version="2.6.2.2" include="All" />
+                <dependency id="Xamarin.AndroidX.Lifecycle.LiveData.Core.Ktx" version="2.6.2.2" include="All" />
+                <dependency id="Xamarin.AndroidX.Lifecycle.Process" version="2.6.2.2" include="All" />
+                <dependency id="Xamarin.AndroidX.Lifecycle.Service" version="2.6.2.2" include="All" />
+                <dependency id="Xamarin.AndroidX.Lifecycle.Extensions" version="2.2.0.16" include="All" />
+                <dependency id="Xamarin.AndroidX.Lifecycle.Runtime.Ktx" version="2.6.2.2" include="All" />
+                <dependency id="Xamarin.Kotlin.StdLib" version="1.9.10.2" include="All" />
+                <dependency id="Xamarin.Kotlin.StdLib.Common" version="1.9.10.2" include="All" />
+                <dependency id="Xamarin.Kotlin.StdLib.Jdk7" version="1.9.10.2" include="All" />
+                <dependency id="Xamarin.Kotlin.StdLib.Jdk8" version="1.9.10.2" include="All" />
+                <dependency id="Xamarin.KotlinX.Coroutines.Core" version="1.7.3.2" include="All" />
+                <dependency id="Xamarin.KotlinX.Coroutines.Core.Jvm" version="1.7.3.2" include="All" />
+                <dependency id="Xamarin.KotlinX.Coroutines.Android" version="1.7.3.2" include="All" />
+                <dependency id="Xamarin.KotlinX.Coroutines.Reactive" version="1.7.3.2" include="All" />
+                <dependency id="Xamarin.KotlinX.Coroutines.Rx3" version="1.7.3.2" include="All" />
+                <dependency id="Xamarin.Google.Dagger" version="2.47.0" include="All" />
+                <dependency id="Xamarin.Google.Android.Material" version="1.7.0.1" include="All" />
+                <dependency id="Square.OkIO.JVM" version="3.5.0" />
+                <dependency id="Xamarin.AndroidX.Security.SecurityCrypto" version="1.1.0-alpha03" />
+                <dependency id="GoogleGson" version="2.10.1.6" include="All" />
+            </group>
             <group targetFramework="MonoAndroid12.0">
                 
                 <!-- Android and AndroidX dependencies -->


### PR DESCRIPTION
# Changelog

## Upgraded Versions

- **GoogleGson**: 2.9.1.1 → 2.10.1.6
- **Square.OkIO.JVM**: 3.0.0.1 → 3.5.0
- **Xamarin.Android.ReactiveX.RxJava**: 2.2.21.8 → 2.2.21.14
- **Xamarin.Android.ReactiveX.RxJava3.RxJava**: 3.1.5.2 → 3.1.8.1
- **Xamarin.AndroidX.Activity**: 1.6.1 → 1.8.0.1
- **Xamarin.AndroidX.Activity.Ktx**: 1.6.1 → 1.8.0.1
- **Xamarin.AndroidX.Annotation**: 1.5.0.1 → 1.7.0.2
- **Xamarin.AndroidX.Annotation.Experimental**: 1.3.0.1 → 1.3.1.3
- **Xamarin.AndroidX.AppCompat**: 1.6.0 → 1.6.1.5
- **Xamarin.AndroidX.Arch.Core.Runtime**: 2.1.0.16 → 2.2.0.5
- **Xamarin.AndroidX.Collection.Ktx**: 1.2.0.5 → 1.3.0.1
- **Xamarin.AndroidX.ConstraintLayout**: 2.1.4.2 → 2.1.4.8
- **Xamarin.AndroidX.Core**: 1.9.0.1 → 1.12.0.2
- **Xamarin.AndroidX.Core.Core.Ktx**: 1.9.0.1 → 1.12.0.2
- **Xamarin.AndroidX.DataBinding.ViewBinding**: 7.4.0 → 8.1.2.1
- **Xamarin.AndroidX.DynamicAnimation**: 1.0.0.15 → 1.0.0.21
- **Xamarin.AndroidX.Fragment.Ktx**: 1.5.5 → 1.6.1.2
- **Xamarin.AndroidX.Legacy.Support.V4**: 1.0.0.15 → 1.0.0.21
- **Xamarin.AndroidX.Lifecycle.Common**: 2.5.1.1 → 2.6.2.2
- **Xamarin.AndroidX.Lifecycle.Extensions**: 2.2.0.15 → 2.2.0.16
- **Xamarin.AndroidX.Lifecycle.LiveData.Core.Ktx**: 2.5.1.1 → 2.6.2.2
- **Xamarin.AndroidX.Lifecycle.Process**: 2.5.1.1 → 2.6.2.2
- **Xamarin.AndroidX.Lifecycle.Runtime.Ktx**: 2.5.1.1 → 2.6.2.2
